### PR TITLE
Set locale to German and update date format in UI

### DIFF
--- a/apps/thomas-szewczyk-cv/src/app/app.config.ts
+++ b/apps/thomas-szewczyk-cv/src/app/app.config.ts
@@ -1,4 +1,8 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import {
+  ApplicationConfig,
+  LOCALE_ID,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
@@ -6,6 +10,10 @@ import { provideMarkdown } from 'ngx-markdown';
 import { provideHttpClient } from '@angular/common/http';
 import { APP_CONFIG, AppConfig } from '@thomas-szewczyk-cv/core/tokens';
 import { environment } from '../environments/environment';
+import { registerLocaleData } from '@angular/common';
+import localeDe from '@angular/common/locales/de';
+
+registerLocaleData(localeDe, 'de');
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -14,6 +22,7 @@ export const appConfig: ApplicationConfig = {
     provideRouter(appRoutes),
     provideAnimationsAsync(),
     provideMarkdown(),
+    { provide: LOCALE_ID, useValue: 'de' },
     {
       provide: APP_CONFIG,
       useValue: <AppConfig>{

--- a/libs/landing/feature-cv/src/cv-certificate-entry/cv-certificate-entry.component.html
+++ b/libs/landing/feature-cv/src/cv-certificate-entry/cv-certificate-entry.component.html
@@ -8,7 +8,7 @@
       <h4>{{ certificate.issuer }}</h4>
       <h4 class="certificate-entry-date">
         <mat-icon>calendar_today</mat-icon>
-        {{ certificate.issueDate | date: 'dd.MM.YYYY': 'de-DE' }}
+        {{ certificate.issueDate | date:'MMMM YYYY' }}
       </h4>
     </div>
   </div>


### PR DESCRIPTION
- Imported and registered German locale data in app configuration.
- Set `LOCALE_ID` to 'de' for consistent localization.
- Modified certificate date format to 'MMMM YYYY' in the CV component.