### PR TITLE
Set baseHref in production configuration

### DIFF
--- a/apps/thomas-szewczyk-cv/project.json
+++ b/apps/thomas-szewczyk-cv/project.json
@@ -46,7 +46,8 @@
               "maximumError": "16kb"
             }
           ],
-          "outputHashing": "all"
+          "outputHashing": "all",
+          "baseHref": "/"
         },
         "development": {
           "optimization": false,


### PR DESCRIPTION
- Added `baseHref` with value `'/'` to the production build configuration in `project.json`.
- Ensures proper base path for application deployment.