### PR TITLE
Add image modal component and integrate with certificate entries

### DIFF
--- a/libs/landing/feature-cv/src/cv-certificate-entry/cv-certificate-entry.component.html
+++ b/libs/landing/feature-cv/src/cv-certificate-entry/cv-certificate-entry.component.html
@@ -1,6 +1,6 @@
 @if($certificate(); as certificate) {
   <div class="certificate-entry">
-    <div class="certificate-entry-image">
+    <div class="certificate-entry-image" (click)="openImage(certificate.thumbnailUrl)">
       <img [src]="certificate.thumbnailUrl" alt="">
     </div>
     <div class="certificate-entry-content">

--- a/libs/landing/feature-cv/src/cv-certificate-entry/cv-certificate-entry.component.scss
+++ b/libs/landing/feature-cv/src/cv-certificate-entry/cv-certificate-entry.component.scss
@@ -32,11 +32,14 @@
   }
 
   .certificate-entry-image {
+    cursor: pointer;
     margin-right: 1rem;
     img {
       width: 100%;
       max-width: 10rem;
       height: auto;
+      border-radius: 0.5rem;
+      border: 1px solid var(--mat-sys-primary-container);
     }
   }
 }

--- a/libs/landing/feature-cv/src/cv-certificate-entry/cv-certificate-entry.component.ts
+++ b/libs/landing/feature-cv/src/cv-certificate-entry/cv-certificate-entry.component.ts
@@ -2,6 +2,8 @@ import { Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CertificateEntry } from '@thomas-szewczyk-cv/landing/data-access';
 import { MatIcon } from '@angular/material/icon';
+import { ImageModalComponent } from '@thomas-szewczyk-cv/ui';
+import { MatDialog } from '@angular/material/dialog';
 
 @Component({
   selector: 'lib-certificate-entry',
@@ -11,4 +13,13 @@ import { MatIcon } from '@angular/material/icon';
 })
 export class CvCertificateEntryComponent {
   $certificate = input<CertificateEntry>();
+
+  constructor(private dialog: MatDialog) {}
+
+  openImage(imageUrl: string) {
+    this.dialog.open(ImageModalComponent, {
+      data: { imageUrl },
+      width: '1200px',
+    });
+  }
 }

--- a/libs/ui/src/components/image-modal/image-modal.component.html
+++ b/libs/ui/src/components/image-modal/image-modal.component.html
@@ -1,0 +1,3 @@
+<div class="image-modal-container">
+  <img [src]="data.imageUrl"  alt=""/>
+</div>

--- a/libs/ui/src/components/image-modal/image-modal.component.scss
+++ b/libs/ui/src/components/image-modal/image-modal.component.scss
@@ -1,0 +1,10 @@
+.image-modal-container {
+  position: relative;
+  text-align: center;
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+}
+

--- a/libs/ui/src/components/image-modal/image-modal.component.spec.ts
+++ b/libs/ui/src/components/image-modal/image-modal.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ImageModalComponent } from './image-modal.component';
+
+describe('ImageModalComponent', () => {
+  let component: ImageModalComponent;
+  let fixture: ComponentFixture<ImageModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ImageModalComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ImageModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/ui/src/components/image-modal/image-modal.component.ts
+++ b/libs/ui/src/components/image-modal/image-modal.component.ts
@@ -1,0 +1,15 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+  selector: 'lib-image-modal',
+  imports: [CommonModule],
+  templateUrl: './image-modal.component.html',
+  styleUrl: './image-modal.component.scss',
+})
+export class ImageModalComponent {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: { imageUrl: string; imageAlt: string }
+  ) {}
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -1,2 +1,3 @@
+export * from './components/image-modal/image-modal.component';
 export * from './components/loading-overlay/loading-overlay.component';
 export * from './components/social-logos/social-logos.component';


### PR DESCRIPTION
- Created `ImageModalComponent`.
- Made `ImageModalComponent` dynamic with Angular Material Dialog and injected data for images.
- Exported `ImageModalComponent` in the UI library index file.
- Integrated image modal in `CvCertificateEntryComponent` for viewing larger certificate images.
- Updated styles to enhance the certificate image appearance and add pointer cursor.